### PR TITLE
Add support for faster_whisper_server

### DIFF
--- a/.sample_env
+++ b/.sample_env
@@ -1,0 +1,8 @@
+OPENAI_API_KEY="sk-<your_key_here>"
+OPENAI_BASE_URL="http://localhost:7000/v1"
+
+OPENAI_MODEL_NAME="Systran/faster-distil-whisper-large-v3"
+# OPENAI_MODEL_NAME="deepdml/faster-whisper-large-v3-turbo-ct2"
+
+UTTERTYPE_RECORD_HOTKEYS="<ctrl>+<alt>+v"
+# UTTERTYPE_RECORD_HOTKEYS="<cmd>+<ctrl>"

--- a/.sample_env
+++ b/.sample_env
@@ -13,3 +13,6 @@ OPENAI_MODEL_NAME="Systran/faster-distil-whisper-large-v3"
 
 UTTERTYPE_RECORD_HOTKEYS="<ctrl>+<alt>+v"
 # UTTERTYPE_RECORD_HOTKEYS="<cmd>+<ctrl>"
+
+# Minimum duration of speech to send to API in case of silence
+UTTERTYPE_MIN_TRANSCRIPTION_SIZE_MS=10000 # defaults to: 1500

--- a/.sample_env
+++ b/.sample_env
@@ -1,3 +1,10 @@
+# Defaults for OpenAI API:
+# OPENAI_API_KEY="sk-<your_key_here>"
+# OPENAI_BASE_URL="https://api.openai.com/v1"
+# OPENAI_MODEL_NAME="whisper-1"
+
+
+# Defaults for local faster_whisper_server:
 OPENAI_API_KEY="sk-<your_key_here>"
 OPENAI_BASE_URL="http://localhost:7000/v1"
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ This will create a virtual environment and install all dependencies from the Pip
 pipenv shell
 ```
 
+
+If during/after installation on Linux you see error similar to:
+```
+ImportError: /home/soul/anaconda3/lib/libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by /lib/x86_64-linux-gnu/libjack.so.0)
+```
+Check out [StackOverflow](https://stackoverflow.com/questions/72540359/glibcxx-3-4-30-not-found-for-librosa-in-conda-virtual-environment-after-tryin) and [Berkley](https://bcourses.berkeley.edu/courses/1478831/pages/glibcxx-missing)
+
+
 ### 4. Configure OpenAI Settings
 
 You can configure uttertype to work with either OpenAI's official API or a local Whisper server. There are two ways to set this up:

--- a/README.md
+++ b/README.md
@@ -19,43 +19,101 @@ python -m pip install pyaudio
 sudo apt-get install python3-pyaudio
 ```
 ### 2. Add a HotKey
-For macOS, the hotkey is automatically set to the globe key by default (&#127760; bottom left key). For Windows and Linux, you will have to set up a custom hotkey for triggering recording, to do this edit the `hotkey` variable in `main.py`:
-```python
-from key_listener import HoldHotKey
-...
-hotkey = HoldHotKey(
-      HoldHotKey.parse("<ctrl>+<alt>+v"),
-      on_activate=transcriber.start_recording,
-      on_deactivate=transcriber.stop_recording,
-  )
+For macOS, the hotkey is automatically set to the globe key by default (&#127760; bottom left key). For Windows and Linux, you can configure the hotkey by setting the `UTTERTYPE_RECORD_HOTKEYS` environment variable in `.env`:
+```env
+UTTERTYPE_RECORD_HOTKEYS="<ctrl>+<alt>+v"
 ```
+
 For more context, view the [pynput documentation for using HotKeys](https://pynput.readthedocs.io/en/latest/keyboard.html#global-hotkeys) (HoldHotKey is extended from this class).
 
-### 3. Install other dependencies
-After cloning the repository, install requirements using
+### 3. Install Dependencies
+Choose one of the following methods to install the required dependencies:
+
+#### Option A: Using pip
 ```shell
 python -m pip install -r requirements.txt
 ```
 
-### 4. Add OpenAI API key
-Make sure that your OpenAI API key is available in the terminal environment either by directly exporting it as follows for macOS/Linux
+#### Option B: Using pipenv
+First, install pipenv if you haven't already:
 ```shell
-export OPENAI_API_KEY=<your_openai_api_key>
+pip install pipenv
 ```
-or as follows for Windows
+
+Then, install dependencies using pipenv:
 ```shell
-$env:OPENAI_API_KEY = "<your_openai_api_key>"
+pipenv install
 ```
-or by creating a file named `.env` in the directory with the following text
+
+This will create a virtual environment and install all dependencies from the Pipfile. To activate the environment:
+```shell
+pipenv shell
+```
+
+### 4. Configure OpenAI Settings
+
+You can configure uttertype to work with either OpenAI's official API or a local Whisper server. There are two ways to set this up:
+
+#### Option A: Using a .env file (Recommended)
+Create a `.env` file in the project directory with these settings:
+
 ```env
-OPENAI_API_KEY=<your_openai_api_key>
+# 1. Required: Your API key
+OPENAI_API_KEY="sk-your-key-here"
+
+# 2. Optional: Choose your API endpoint
+# For OpenAI's official API (default):
+OPENAI_BASE_URL="https://api.openai.com/v1"
+# OR for a local [Faster Whisper server](https://github.com/fedirz/faster-whisper-server):
+OPENAI_BASE_URL="http://localhost:7000/v1"
+
+# 3. Optional: Select your preferred model
+# For OpenAI's official API:
+OPENAI_MODEL_NAME="whisper-1"
+# OR for local Whisper server, some options include:
+OPENAI_MODEL_NAME="Systran/faster-whisper-small"
+OPENAI_MODEL_NAME="Systran/faster-distil-whisper-large-v3"
+OPENAI_MODEL_NAME="deepdml/faster-whisper-large-v3-turbo-ct2"
 ```
+
+#### Option B: Using Environment Variables
+You can also set these values directly in your terminal:
+
+For Linux/macOS:
+```shell
+export OPENAI_API_KEY="sk-your-key-here"
+export OPENAI_BASE_URL="https://api.openai.com/v1" # optional
+export OPENAI_MODEL_NAME="whisper-1" # optional
+```
+
+For Windows:
+```shell
+$env:OPENAI_API_KEY = "sk-your-key-here"
+$env:OPENAI_BASE_URL = "https://api.openai.com/v1"  # optional
+$env:OPENAI_MODEL_NAME = "whisper-1"  # optional
+```
+
+See [`.sample_env`](.sample_env) in the repository for example configurations.
+
+#### Using a Local Whisper Server
+For faster and cheaper transcription, you can set up a local [faster-whisper-server](https://github.com/fedirz/faster-whisper-server). When using a local server:
+
+1. Set `OPENAI_BASE_URL` to your server's address (e.g., `http://localhost:7000/v1`)
+2. Choose from supported local models like:
+   - `Systran/faster-whisper-small` (fastest)
+   - `Systran/faster-distil-whisper-large-v3` (most accurate)
+   - `deepdml/faster-whisper-large-v3-turbo-ct2` (almost as good, but faster)
 
 ### 5. Final run and permissions
 Finally, run main.py
 ```shell
 python main.py
 ```
+OR
+```shell
+./start_uttertype.sh # installed and configured pipenv environment would be needed
+```
+
 When the program first runs, you will likely need to give it sufficient permissions. On macOS, this will include adding terminal to accessibility under `Privacy and Security > Accessibility`, giving it permission to monitor the keyboard, and finally giving it permission to record using the microphone.
 
 ## Usage

--- a/key_listener.py
+++ b/key_listener.py
@@ -1,3 +1,5 @@
+import os
+import sys
 from pynput.keyboard import HotKey
 
 
@@ -43,3 +45,21 @@ class HoldGlobeKey:
     def release(self, key):
         """Press and release signals are mixed for globe key"""
         self.press(key)
+
+
+def create_keylistener(transcriber, env_var="UTTERTYPE_RECORD_HOTKEYS"):
+    key_code = os.getenv(env_var, "")
+
+    if (sys.platform == "darwin") and (key_code in ["<globe>", ""]):
+        return HoldGlobeKey(
+            on_activate=transcriber.start_recording,
+            on_deactivate=transcriber.stop_recording,
+        )
+
+    key_code = key_code if key_code else "<ctrl>+<alt>+v"
+
+    return HoldHotKey(
+          HoldHotKey.parse(key_code),
+          on_activate=transcriber.start_recording,
+          on_deactivate=transcriber.stop_recording,
+      )

--- a/main.py
+++ b/main.py
@@ -2,18 +2,17 @@ import asyncio
 from pynput import keyboard
 from transcriber import WhisperAPITranscriber
 from table_interface import ConsoleTable
-from key_listener import HoldGlobeKey
+from key_listener import create_keylistener
 from dotenv import load_dotenv
 from utils import manual_type
 
 
 async def main():
     load_dotenv()
-    transcriber = WhisperAPITranscriber()
-    hotkey = HoldGlobeKey(
-        on_activate=transcriber.start_recording,
-        on_deactivate=transcriber.stop_recording,
-    )
+
+    transcriber = WhisperAPITranscriber.create()
+    hotkey = create_keylistener(transcriber)
+
     keyboard.Listener(on_press=hotkey.press, on_release=hotkey.release).start()
     console_table = ConsoleTable()
     with console_table:

--- a/start_uttertype.sh
+++ b/start_uttertype.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Get directory of the script
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Check if tmux is installed
+if ! command -v tmux &> /dev/null; then
+    echo "tmux is not installed. Please install it first."
+    exit 1
+fi
+
+# Check if pipenv is installed and create virtual environment if needed
+if command -v pipenv &> /dev/null; then
+    cd "$SCRIPT_DIR"
+    # Create/update virtual environment if needed
+    pipenv install --quiet
+    # Get the path to the virtual environment's Python
+    VENV_PYTHON=$(pipenv --py)
+else
+    echo "pipenv is not installed. Using system Python."
+    VENV_PYTHON=$(which python)
+fi
+
+# Create new tmux session if it doesn't exist
+if ! tmux has-session -t uttertype 2>/dev/null; then
+    tmux new-session -s uttertype -d
+    tmux send-keys -t uttertype "cd '$SCRIPT_DIR' && '$VENV_PYTHON' main.py" C-m
+fi

--- a/transcriber.py
+++ b/transcriber.py
@@ -131,14 +131,23 @@ class AudioTranscriber:
 
 
 class WhisperAPITranscriber(AudioTranscriber):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, base_url, model_name, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.client = OpenAI()
+
+        self.model_name = model_name
+        self.client = OpenAI(base_url=base_url)
+
+    @staticmethod
+    def create(*args, **kwargs):
+        base_url = os.getenv('OPENAI_BASE_URL', 'https://api.openai.com/v1')
+        model_name = os.getenv('OPENAI_MODEL_NAME', 'whisper-1')
+
+        return WhisperAPITranscriber(base_url, model_name)
 
     def transcribe_audio(self, audio: io.BytesIO) -> str:
         try:
             transcription = self.client.audio.transcriptions.create(
-                model="whisper-1",
+                model=self.model_name,
                 file=audio,
                 response_format="text",
                 language="en",

--- a/transcriber.py
+++ b/transcriber.py
@@ -15,7 +15,7 @@ CHANNELS = 1  # Mono audio
 RATE = 16000  # Sample rate
 CHUNK_DURATION_MS = 30  # Frame duration in milliseconds
 CHUNK = int(RATE * CHUNK_DURATION_MS / 1000)
-MIN_TRANSCRIPTION_SIZE_MS = (
+MIN_TRANSCRIPTION_SIZE_MS = int(
     os.getenv('UTTERTYPE_MIN_TRANSCRIPTION_SIZE_MS', 1500) # Minimum duration of speech to send to API in case of silence
 )
 

--- a/transcriber.py
+++ b/transcriber.py
@@ -16,7 +16,7 @@ RATE = 16000  # Sample rate
 CHUNK_DURATION_MS = 30  # Frame duration in milliseconds
 CHUNK = int(RATE * CHUNK_DURATION_MS / 1000)
 MIN_TRANSCRIPTION_SIZE_MS = (
-    1500  # Minimum duration of speech to send to API in case of silence
+    os.getenv('UTTERTYPE_MIN_TRANSCRIPTION_SIZE_MS', 1500) # Minimum duration of speech to send to API in case of silence
 )
 
 


### PR DESCRIPTION
faster whisper server (https://github.com/fedirz/faster-whisper-server) has API identical to the OpenAI's API.  So the only thing that is needed to support it are the environment variables. To direct the OpenAI's library to the local url.