### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,15 @@
 
 ### 1. [Install PortAudio/PyAudio](https://people.csail.mit.edu/hubert/pyaudio/)
 #### macOS
-Installing portaudio on macOS can be somewhat tricky, especially on M1+ chips. In general, using conda seems to be the safest way to install portaudio
+Installing portaudio on macOS can be somewhat tricky, especially on M1+ chips (Apple Silicon). In general, using conda seems to be the safest way to install portaudio
 ```
 conda install portaudio
 ```
+If that doesn't work, try installing using Homebrew
+```sh
+brew install portaudio
+```
+
 #### Windows
 ```
 python -m pip install pyaudio


### PR DESCRIPTION
Homebrew is de-facto standard package manager for macOS system-wide packages.

Here's the error I got after trying to install using conda:

```sh
 > conda install portaudio
Channels:
 - defaults
Platform: osx-arm64
Collecting package metadata (repodata.json): done
Solving environment: failed

PackagesNotFoundError: The following packages are not available from current channels:

  - portaudio

Current channels:

  - https://repo.anaconda.com/pkgs/main
  - https://repo.anaconda.com/pkgs/r

To search for alternate channels that may provide the conda package you're
looking for, navigate to

    https://anaconda.org

and use the search bar at the top of the page.
```

Here's the output trying to install using Homebrew:

```sh
> brew install portaudio
==> Downloading https://ghcr.io/v2/homebrew/core/portaudio/manifests/19.7.0-1
############################################################################################################################################################################################################################ 100.0%
==> Fetching portaudio
==> Downloading https://ghcr.io/v2/homebrew/core/portaudio/blobs/sha256:8ad9f1c15a4bc9c05a9dd184b53b8f5f5d13a2458a70535bfb01e54ce4f8b4bd
############################################################################################################################################################################################################################ 100.0%
==> Pouring portaudio--19.7.0.arm64_sequoia.bottle.1.tar.gz
🍺  /opt/homebrew/Cellar/portaudio/19.7.0: 34 files, 546.0KB
```